### PR TITLE
113TourRouterAndOtherChanges

### DIFF
--- a/planning/server/api/audio_files/POST_audio_file.md
+++ b/planning/server/api/audio_files/POST_audio_file.md
@@ -21,6 +21,10 @@ The audio file must have key name "audio"
 
 # SUCCESS RESPONSE BODY
 ```
-"Audio file added"
+{
+  "_id": "607e399459c86677e83n65r7",
+  "audio_file_url": "s3.aws.indigenousplantgo.com/audio/roses-speech.mp3",
+  "caption": "A speech about roses"
+}
 ```
 

--- a/planning/server/api/categories/GET_categories.md
+++ b/planning/server/api/categories/GET_categories.md
@@ -12,15 +12,18 @@ Example request: GET /api/categories?key=<API_KEY>
 [
   {
     "_id": "607e399e59c86677e2af6587",
-    "category_name": "Event"
+    "category_name": "Event",
+    "resource": "plant"
   },
   {
     "_id": "607e399e59c86677e2asda77",
-    "category_name": "Community Outreach"
+    "category_name": "Community Outreach",
+    "resource": "waypoint"
   },
   {
     "_id": "607e399e59c86677s72sda77",
-    "category_name": "Students"
+    "category_name": "Students",
+    "resource": "tour"
   }
   // ... Repeat
 ]

--- a/planning/server/api/categories/GET_category.md
+++ b/planning/server/api/categories/GET_category.md
@@ -11,6 +11,7 @@ Example request: GET /api/categories/607e399e59c86677e2af6587?key=<API_KEY>
 ```
 {
   "_id": "607e399e59c86677e2af6587",
-  "category_name": "Event"
+  "category_name": "Event",
+  "resource": "plant"
 }
 ```

--- a/planning/server/api/categories/GET_category_group.md
+++ b/planning/server/api/categories/GET_category_group.md
@@ -1,0 +1,20 @@
+# Get category group
+@desc GET single category
+
+@route /api/categories/group/:group
+
+@access Protected -- API key
+
+Example request: GET /api/categories/group/plant?key=<API_KEY>
+
+# EXAMPLE RESPONSE BODY
+```
+[
+  {
+    "_id": "607e399e59c86677e2af6587",
+    "category_name": "Event",
+    "resource": "plant"
+  }
+  // ... Repeat
+]
+```

--- a/planning/server/api/categories/POST_category.md
+++ b/planning/server/api/categories/POST_category.md
@@ -19,5 +19,9 @@ Resource field is provided by the frontend depending on where the category is cr
 
 # SUCCESS RESPONSE BODY
 ```
-"Category added"
+{
+  "_id": "607e399e59c86677e2af6587",
+  "category_name": "Event",
+  "resource": "plant"
+}
 ```

--- a/planning/server/api/categories/POST_category.md
+++ b/planning/server/api/categories/POST_category.md
@@ -10,9 +10,12 @@ Example request: POST /api/categories?key=<API_KEY>
 # EXAMPLE REQUEST BODY
 ```
 {
-  "category_name": "Event"
+  "category_name": "Event",
+  "resource": "plant"
 }
 ```
+
+Resource field is provided by the frontend depending on where the category is created under
 
 # SUCCESS RESPONSE BODY
 ```

--- a/planning/server/api/images/POST_image.md
+++ b/planning/server/api/images/POST_image.md
@@ -21,6 +21,10 @@ The image file must have key name "image"
 
 # SUCCESS RESPONSE BODY
 ```
-"Image added"
+{
+  "_id": "607e399e59c8feg7e2af65r7",
+  "image_url": "s3.aws.indigenousplantgo.com/images/lavender-1",
+  "caption": "lavender in a big field"
+}
 ```
 

--- a/planning/server/api/locations/POST_location.md
+++ b/planning/server/api/locations/POST_location.md
@@ -20,5 +20,10 @@ Descripion will default to an empty string if it is not provided in the request 
 
 # SUCCESS RESPONSE BODY
 ```
-"Location added"
+{ 
+  "_id": "607e3ab0a0d3df815abfcfb1",
+  "location_name": "Lot A",
+  "coordinates": "49°15&#39;16.2&quot;N 122°59&#39;53.7&quot;W",
+  "description": ""
+}
 ```

--- a/planning/server/api/plants/POST_plant.md
+++ b/planning/server/api/plants/POST_plant.md
@@ -19,9 +19,17 @@ Example request: POST /api/plants?key=<API_KEY>
   "tags": ["607e4qwee59c86677e2af65r7", "607e384559c86677e2af65r7"],
   "categories": ["607e4qwee59c86677e2ewe3447"],
   "locations": ["607e3ab0a0d3df815abfcfb1"],
-  "custom_fields": ["607e399e59c86677e2af65r7", "607e399e59c86677e465r7"]
+  "custom_fields": [
+    {
+      custom_field_id: "607e399e59c86677e2af65r7",
+      field_title: "Medical",
+      content: "Use in medical"
+    }
+  ]
 }
 ```
+
+Plant_name, scientific_name, and description are required fields
 
 If an array field is not provided it will default to empty array
 

--- a/planning/server/api/plants/PUT_plant.md
+++ b/planning/server/api/plants/PUT_plant.md
@@ -19,7 +19,13 @@ Example request: PUT /api/plants/607e399e59c8feg7e2af65r7
   "tags": ["607e4qwee59c86677e2af65r7", "607e384559c86677e2af65r7"],
   "categories": ["607e4qwee59c86677e2ewe3447"],
   "locations": ["607e3ab0a0d3df815abfcfb1"],
-  "custom_fields": ["607e399e59c86677e2af65r7", "607e399e59c86677e465r7"]
+  "custom_fields": [
+    {
+      custom_field_id: "607e399e59c86677e2af65r7",
+      field_title: "Medical",
+      content: "Use in medical"
+    }
+  ]
 }
 ```
 

--- a/planning/server/api/tags/POST_tag.md
+++ b/planning/server/api/tags/POST_tag.md
@@ -16,5 +16,8 @@ Example request: POST /api/tags?key=<API_KEY>
 
 # SUCCESS RESPONSE BODY
 ```
-"Tag added"
+{
+  "_id": "607e399e59c86677e2af6587",
+  "tag_name": "Event"
+}
 ```

--- a/planning/server/api/tours/DELETE_tour.md
+++ b/planning/server/api/tours/DELETE_tour.md
@@ -1,0 +1,15 @@
+# Delete tour
+@desc DELETE single tour
+
+@route /api/tours/:id
+
+@access Protected -- require user login
+
+Example request: DELETE /api/tours/607e399e59c8feg7e2af65r7
+
+This will also delete all the revision under the deleted tour
+
+# SUCCESS RESPONSE BODY
+```
+"Tour deleted"
+```

--- a/planning/server/api/tours/GET_tour.md
+++ b/planning/server/api/tours/GET_tour.md
@@ -1,12 +1,14 @@
-/*
-  @desc GET a single tour
-  @route /api/tour/:id
-  @access Protected -- API key
+# Get tour
+@desc GET a single tour
 
-  Example request: GET /api/tour/607e399e59c86677e2af6587?key=<API_KEY>
-*/
+@route /api/tour/:id
 
-// EXAMPLE RESPONSE BODY
+@access Protected -- API key
+
+Example request: GET /api/tour/607e399e59c86677e2af6587?key=<API_KEY>
+
+# EXAMPLE RESPONSE BODY
+```
 {
   "_id": "607e399e59c86677e2af6587",
   "tour_name": "The English Walk",
@@ -335,3 +337,4 @@
     },
   ]
 }
+```

--- a/planning/server/api/tours/GET_tours.md
+++ b/planning/server/api/tours/GET_tours.md
@@ -1,12 +1,14 @@
-/*
-  @desc GET all tours
-  @route /api/tours
-  @access Protected -- API key
+# Get tours
+@desc GET all tours
 
-  Example request: GET /api/tours?key=<API_KEY>
-*/
+@route /api/tours
 
-// EXAMPLE RESPONSE BODY
+@access Protected -- API key
+
+Example request: GET /api/tours?key=<API_KEY>
+
+# EXAMPLE RESPONSE BODY
+```
 [
   {
     "_id": "607e399e59c86677e2af6587",
@@ -338,3 +340,4 @@
   }
   // ... Repeat 
 ]
+```

--- a/planning/server/api/tours/POST_tour.md
+++ b/planning/server/api/tours/POST_tour.md
@@ -1,24 +1,24 @@
-# Create waypoint
-@desc POST single waypoint
+# Create tour
+@desc POST single tour
 
-@route /api/waypoints
+@route /api/tours
 
 @access Protected -- API key, require user login
 
-Example request: POST /api/waypoints?key=<API_KEY>
+Example request: POST /api/tours?key=<API_KEY>
 
 # EXAMPLE REQUEST BODY
 ```
 {
-  "waypoint_name": "test",
+  "tour_name": "test",
   "description": "test",
   "images": ["607fa01931325a2e700a4307"],
   "audio_files": ["607fa01931325a2e700a4307"],
   "videos": ["607fa01931325a2e700a4307"],
   "tags": ["607fa01931325a2e700a4307", "607fa01931325a2e700a4307"],
   "categories": ["607fa01931325a2e700a4307"],
-  "location": "607fa01931325a2e700a4307",
   "plants": ["607fa01931325a2e700a4307"],
+  "waypoints": ["607fa01931325a2e700a4307"],
   "custom_fields": [
     {
       custom_field_id: "607e399e59c86677e2af65r7",
@@ -29,13 +29,13 @@ Example request: POST /api/waypoints?key=<API_KEY>
 }
 ```
 
-Waypoint_name, description, and location are required fields
+tour_name, and description are required fields
 
 If an array field is not provided it will default to empty array
 
-On create, a new revision will be set base on the user creating the waypoint
+On create, a new revision will be set base on the user creating the tour
 
 # SUCCESS RESPONSE BODY
 ```
-"Waypoint added"
+"Tour added"
 ```

--- a/planning/server/api/tours/PUT_tour.md
+++ b/planning/server/api/tours/PUT_tour.md
@@ -1,25 +1,25 @@
-# Create waypoint
-@desc POST single waypoint
+# Update tour
+@desc PUT single tour
 
-@route /api/waypoints
+@route /api/tours/:id
 
-@access Protected -- API key, require user login
+@access Protected -- require user login
 
-Example request: POST /api/waypoints?key=<API_KEY>
+Example request: PUT /api/tours/607e399e59c8feg7e2af65r7
 
 # EXAMPLE REQUEST BODY
 ```
 {
-  "waypoint_name": "test",
+  "tour_name": "test",
   "description": "test",
   "images": ["607fa01931325a2e700a4307"],
   "audio_files": ["607fa01931325a2e700a4307"],
   "videos": ["607fa01931325a2e700a4307"],
   "tags": ["607fa01931325a2e700a4307", "607fa01931325a2e700a4307"],
   "categories": ["607fa01931325a2e700a4307"],
-  "location": "607fa01931325a2e700a4307",
   "plants": ["607fa01931325a2e700a4307"],
-  "custom_fields": [
+  "waypoints": ["607fa01931325a2e700a4307"],
+  "custom_fields": "custom_fields": [
     {
       custom_field_id: "607e399e59c86677e2af65r7",
       field_title: "Medical",
@@ -29,13 +29,11 @@ Example request: POST /api/waypoints?key=<API_KEY>
 }
 ```
 
-Waypoint_name, description, and location are required fields
+We set it to overwrite existing data
 
-If an array field is not provided it will default to empty array
-
-On create, a new revision will be set base on the user creating the waypoint
+New revision is added on whenever update is made
 
 # SUCCESS RESPONSE BODY
 ```
-"Waypoint added"
+"Tour updated"
 ```

--- a/planning/server/api/users/POST_user_login.md
+++ b/planning/server/api/users/POST_user_login.md
@@ -8,15 +8,15 @@ Example request: POST /api/users/login
 # EXAMPLE REQUEST BODY
 ```
 {
-  "username": "test",
+  "user_name": "test",
   "password": "<encrypted>"
 }
 ```
 
-For the username input you can also put the email like such:
+For the user_name input you can also put the email like such:
 ```
 {
-  "username": "test@email.com",
+  "user_name": "test@email.com",
   "password": "<encrypted>"
 }
 ```
@@ -28,7 +28,7 @@ For the username input you can also put the email like such:
   "user": {
       "_id": "6081c2dd1d083738f4458862",
       "email": "test@email.com",
-      "username": "test",
+      "user_name": "test",
       "role": "Admin"
   }
 }

--- a/planning/server/api/users/POST_users.md
+++ b/planning/server/api/users/POST_users.md
@@ -9,7 +9,7 @@ Example request: POST /api/users
 ```
 {
   "email": "test@email.com",
-  "username": "test",
+  "user_name": "test",
   "password": "test",
   "role": "Admin"
 }
@@ -24,7 +24,7 @@ Role is default to Manager if no role is inputed
   "user": {
       "_id": "6081c2dd1d083738f4458862",
       "email": "test@email.com",
-      "username": "test",
+      "user_name": "test",
       "role": "Admin"
   }
 }

--- a/planning/server/api/users/PUT_user.md
+++ b/planning/server/api/users/PUT_user.md
@@ -11,7 +11,7 @@ Example request: PUT /api/users/607e399e59c8feg7e2af65r7
 ```
 {
   "email": "test@email.com",
-  "username": "test",
+  "user_name": "test",
   "password": "test",
   "role": "Admin"
 }

--- a/planning/server/api/videos/POST_video.md
+++ b/planning/server/api/videos/POST_video.md
@@ -21,5 +21,9 @@ The video file must have key name "video"
 
 # SUCCESS RESPONSE BODY
 ```
-"Video added"
+{
+  "_id": "607e384559c86677e2af65r7",
+  "video_url": "s3.aws.indigenousplantgo.com/video/lavender-bloom.mp4",
+  "caption": "A lavender flower blooming timelapse"
+}
 ```

--- a/planning/server/api/waypoints/DELETE_waypoint.md
+++ b/planning/server/api/waypoints/DELETE_waypoint.md
@@ -1,0 +1,15 @@
+# Delete waypoint
+@desc DELETE single waypoint
+
+@route /api/waypoints/:id
+
+@access Protected -- require user login
+
+Example request: DELETE /api/waypoints/607e399e59c8feg7e2af65r7
+
+This will also delete all the revision under the deleted waypoint
+
+# SUCCESS RESPONSE BODY
+```
+"Waypoint deleted"
+```

--- a/planning/server/api/waypoints/GET_waypoint.md
+++ b/planning/server/api/waypoints/GET_waypoint.md
@@ -1,12 +1,12 @@
-/*
-  @desc GET a single waypoint
-  @route /api/waypoint/:id
-  @access Protected -- API key
+# Get waypoint
+@desc GET a single waypoint
+@route /api/waypoint/:id
+@access Protected -- API key
 
-  Example request: GET /api/waypoint/607e399e59c86677e2af6587?key=<API_KEY>
-*/
+Example request: GET /api/waypoint/607e399e59c86677e2af6587?key=<API_KEY>
 
-// EXAMPLE RESPONSE BODY
+# EXAMPLE RESPONSE BODY
+```
 {
   "_id": "607e399e59c86677e2af6587",
   "waypoint_name": "The Indigenous Initiatives Gathering Place",
@@ -175,3 +175,4 @@
     }
   ]
 }
+```

--- a/planning/server/api/waypoints/GET_waypoints.md
+++ b/planning/server/api/waypoints/GET_waypoints.md
@@ -1,12 +1,12 @@
-/*
-  @desc GET all waypoints
-  @route /api/waypoints
-  @access Protected -- API key
+# Get waypoints
+@desc GET all waypoints
+@route /api/waypoints
+@access Protected -- API key
 
-  Example request: GET /api/waypoints?key=<API_KEY>
-*/
+Example request: GET /api/waypoints?key=<API_KEY>
 
-// EXAMPLE RESPONSE BODY
+# EXAMPLE RESPONSE BODY
+```
 [
   {
     "_id": "607e399e59c86677e2af6587",
@@ -178,3 +178,4 @@
   }
   // ...Repeat
 ]
+```

--- a/planning/server/api/waypoints/POST_waypoint.md
+++ b/planning/server/api/waypoints/POST_waypoint.md
@@ -1,0 +1,40 @@
+# Create waypoint
+@desc POST single waypoint
+
+@route /api/waypoints
+
+@access Protected -- API key, require user login
+
+Example request: POST /api/waypoints?key=<API_KEY>
+
+# EXAMPLE REQUEST BODY
+```
+{
+  "waypoint_name": "test",
+  "description": "test",
+  "images": ["607fa01931325a2e700a4307"],
+  "audio_files": ["607fa01931325a2e700a4307"],
+  "videos": ["607fa01931325a2e700a4307"],
+  "tags": ["607fa01931325a2e700a4307", "607fa01931325a2e700a4307"],
+  "categories": ["607fa01931325a2e700a4307"],
+  "location": "607fa01931325a2e700a4307",
+  "custom_fields": [
+    {
+      custom_field_id: "607e399e59c86677e2af65r7",
+      field_title: "Medical",
+      content: "Use in medical"
+    }
+  ]
+}
+```
+
+Waypoint_name, description, and location are required fields
+
+If an array field is not provided it will default to empty array
+
+On create, a new revision will be set base on the user creating the waypoint
+
+# SUCCESS RESPONSE BODY
+```
+"Waypoint added"
+```

--- a/planning/server/api/waypoints/PUT_waypoint.md
+++ b/planning/server/api/waypoints/PUT_waypoint.md
@@ -18,6 +18,7 @@ Example request: PUT /api/waypoints/607e399e59c8feg7e2af65r7
   "tags": ["607fa01931325a2e700a4307", "607fa01931325a2e700a4307"],
   "categories": ["607fa01931325a2e700a4307"],
   "location": "607fa01931325a2e700a4307",
+  "plants": ["607fa01931325a2e700a4307"],
   "custom_fields": "custom_fields": [
     {
       custom_field_id: "607e399e59c86677e2af65r7",

--- a/planning/server/api/waypoints/PUT_waypoint.md
+++ b/planning/server/api/waypoints/PUT_waypoint.md
@@ -1,0 +1,38 @@
+# Update waypoint
+@desc PUT single waypoint
+
+@route /api/waypoints/:id
+
+@access Protected -- require user login
+
+Example request: PUT /api/waypoints/607e399e59c8feg7e2af65r7
+
+# EXAMPLE REQUEST BODY
+```
+{
+  "waypoint_name": "test",
+  "description": "test",
+  "images": ["607fa01931325a2e700a4307"],
+  "audio_files": ["607fa01931325a2e700a4307"],
+  "videos": ["607fa01931325a2e700a4307"],
+  "tags": ["607fa01931325a2e700a4307", "607fa01931325a2e700a4307"],
+  "categories": ["607fa01931325a2e700a4307"],
+  "location": "607fa01931325a2e700a4307",
+  "custom_fields": "custom_fields": [
+    {
+      custom_field_id: "607e399e59c86677e2af65r7",
+      field_title: "Medical",
+      content: "Use in medical"
+    }
+  ]
+}
+```
+
+We set it to overwrite existing data
+
+New revision is added on whenever update is made
+
+# SUCCESS RESPONSE BODY
+```
+"Waypoint updated"
+```

--- a/server/mongoDatabase.js
+++ b/server/mongoDatabase.js
@@ -566,7 +566,7 @@ module.exports = async function() {
     }
 
     const result = await revisions.insertOne({
-      user_id,
+      user_id: ObjectID(user_id),
       date: Date.now().toString()
     })
     return result
@@ -649,6 +649,37 @@ module.exports = async function() {
           localField: 'revision_history',
           foreignField: '_id',
           as: 'revision_history'
+        }
+      },
+      {
+        $unwind: {
+          path: '$revision_history'
+        }
+      },
+      {
+        $lookup: {
+          from: 'users',
+          localField: 'revision_history.user',
+          foreignField: '_id',
+          as: 'revision_history.user'
+        }
+      },
+      {
+        $group: {
+          _id: '$_id',
+          images: {$first: '$images'},
+          audio_files: {$first: '$audio_files'},
+          videos: {$first: '$videos'},
+          tags: {$first: '$tags'},
+          categories: {$first: '$categories'},
+          locations: {$first: '$locations'},
+          custom_fields: {$first: '$custom_fields'},
+          revision_history: {$push: '$revision_history'}
+        }
+      },
+      {
+        $project: {
+          'revision_history.user.password': 0
         }
       }
     ]
@@ -802,6 +833,37 @@ module.exports = async function() {
           foreignField: '_id',
           as: 'revision_history'
         }
+      },
+      {
+        $unwind: {
+          path: '$revision_history'
+        }
+      },
+      {
+        $lookup: {
+          from: 'users',
+          localField: 'revision_history.user',
+          foreignField: '_id',
+          as: 'revision_history.user'
+        }
+      },
+      {
+        $group: {
+          _id: '$_id',
+          images: {$first: '$images'},
+          audio_files: {$first: '$audio_files'},
+          videos: {$first: '$videos'},
+          tags: {$first: '$tags'},
+          categories: {$first: '$categories'},
+          locations: {$first: '$locations'},
+          custom_fields: {$first: '$custom_fields'},
+          revision_history: {$push: '$revision_history'}
+        }
+      },
+      {
+        $project: {
+          'revision_history.user.password': 0
+        }
       }
     ]
 
@@ -935,6 +997,14 @@ module.exports = async function() {
       },
       {
         $lookup: {
+          from: 'plants',
+          localField: 'plants',
+          foreignField: '_id',
+          as: 'plants'
+        }
+      },
+      {
+        $lookup: {
           from: 'revisions',
           localField: 'revision_history',
           foreignField: '_id',
@@ -942,11 +1012,35 @@ module.exports = async function() {
         }
       },
       {
+        $unwind: {
+          path: '$revision_history'
+        }
+      },
+      {
         $lookup: {
-          from: 'plants',
-          localField: 'plants',
+          from: 'users',
+          localField: 'revision_history.user',
           foreignField: '_id',
-          as: 'plants'
+          as: 'revision_history.user'
+        }
+      },
+      {
+        $group: {
+          _id: '$_id',
+          images: {$first: '$images'},
+          audio_files: {$first: '$audio_files'},
+          videos: {$first: '$videos'},
+          tags: {$first: '$tags'},
+          categories: {$first: '$categories'},
+          location: {$first: '$location'},
+          plants: {$first: '$plants'},
+          custom_fields: {$first: '$custom_fields'},
+          revision_history: {$push: '$revision_history'}
+        }
+      },
+      {
+        $project: {
+          'revision_history.user.password': 0
         }
       }
     ]
@@ -1097,6 +1191,14 @@ module.exports = async function() {
       },
       {
         $lookup: {
+          from: 'plants',
+          localField: 'plants',
+          foreignField: '_id',
+          as: 'plants'
+        }
+      },
+      {
+        $lookup: {
           from: 'revisions',
           localField: 'revision_history',
           foreignField: '_id',
@@ -1104,11 +1206,35 @@ module.exports = async function() {
         }
       },
       {
+        $unwind: {
+          path: '$revision_history'
+        }
+      },
+      {
         $lookup: {
-          from: 'plants',
-          localField: 'plants',
+          from: 'users',
+          localField: 'revision_history.user',
           foreignField: '_id',
-          as: 'plants'
+          as: 'revision_history.user'
+        }
+      },
+      {
+        $group: {
+          _id: '$_id',
+          images: {$first: '$images'},
+          audio_files: {$first: '$audio_files'},
+          videos: {$first: '$videos'},
+          tags: {$first: '$tags'},
+          categories: {$first: '$categories'},
+          location: {$first: '$location'},
+          plants: {$first: '$plants'},
+          custom_fields: {$first: '$custom_fields'},
+          revision_history: {$push: '$revision_history'}
+        }
+      },
+      {
+        $project: {
+          'revision_history.user.password': 0
         }
       }
     ]
@@ -1239,14 +1365,6 @@ module.exports = async function() {
       },
       {
         $lookup: {
-          from: 'revisions',
-          localField: 'revision_history',
-          foreignField: '_id',
-          as: 'revision_history'
-        }
-      },
-      {
-        $lookup: {
           from: 'plants',
           localField: 'plants',
           foreignField: '_id',
@@ -1259,6 +1377,46 @@ module.exports = async function() {
           localField: 'waypoints',
           foreignField: '_id',
           as: 'waypoints'
+        }
+      },
+      {
+        $lookup: {
+          from: 'revisions',
+          localField: 'revision_history',
+          foreignField: '_id',
+          as: 'revision_history'
+        }
+      },
+      {
+        $unwind: {
+          path: '$revision_history'
+        }
+      },
+      {
+        $lookup: {
+          from: 'users',
+          localField: 'revision_history.user',
+          foreignField: '_id',
+          as: 'revision_history.user'
+        }
+      },
+      {
+        $group: {
+          _id: '$_id',
+          images: {$first: '$images'},
+          audio_files: {$first: '$audio_files'},
+          videos: {$first: '$videos'},
+          tags: {$first: '$tags'},
+          categories: {$first: '$categories'},
+          plants: {$first: '$plants'},
+          waypoints: {$first: '$waypoints'},
+          custom_fields: {$first: '$custom_fields'},
+          revision_history: {$push: '$revision_history'}
+        }
+      },
+      {
+        $project: {
+          'revision_history.user.password': 0
         }
       }
     ]
@@ -1403,14 +1561,6 @@ module.exports = async function() {
       },
       {
         $lookup: {
-          from: 'revisions',
-          localField: 'revision_history',
-          foreignField: '_id',
-          as: 'revision_history'
-        }
-      },
-      {
-        $lookup: {
           from: 'plants',
           localField: 'plants',
           foreignField: '_id',
@@ -1423,6 +1573,46 @@ module.exports = async function() {
           localField: 'waypoints',
           foreignField: '_id',
           as: 'waypoints'
+        }
+      },
+      {
+        $lookup: {
+          from: 'revisions',
+          localField: 'revision_history',
+          foreignField: '_id',
+          as: 'revision_history'
+        }
+      },
+      {
+        $unwind: {
+          path: '$revision_history'
+        }
+      },
+      {
+        $lookup: {
+          from: 'users',
+          localField: 'revision_history.user',
+          foreignField: '_id',
+          as: 'revision_history.user'
+        }
+      },
+      {
+        $group: {
+          _id: '$_id',
+          images: {$first: '$images'},
+          audio_files: {$first: '$audio_files'},
+          videos: {$first: '$videos'},
+          tags: {$first: '$tags'},
+          categories: {$first: '$categories'},
+          plants: {$first: '$plants'},
+          waypoints: {$first: '$waypoints'},
+          custom_fields: {$first: '$custom_fields'},
+          revision_history: {$push: '$revision_history'}
+        }
+      },
+      {
+        $project: {
+          'revision_history.user.password': 0
         }
       }
     ]

--- a/server/mongoDatabase.js
+++ b/server/mongoDatabase.js
@@ -28,10 +28,10 @@ module.exports = async function() {
   //Create new user, use for register
   //Takes in email, username and password, role default to Manager
   //POST /api/users
-  async function createUser({email, username, password, role="Manager"}) {
+  async function createUser({email, user_name, password, role="Manager"}) {
     //Check if email or username is repeating
     const user = await users.findOne({
-      $or: [{email: email}, {username: username}]
+      $or: [{email: email}, {user_name: user_name}]
     })
     if (user) {
       throw Error("Username or email is already taken")
@@ -50,7 +50,7 @@ module.exports = async function() {
 
     const result = await users.insertOne({
       email,
-      username,
+      user_name,
       password: encrypted,
       role
     })
@@ -62,9 +62,9 @@ module.exports = async function() {
   //Get One user, use for login
   //Takes in email/username and password and find one user that match
   //POST /api/users/login
-  async function getUser({username, password}) {
+  async function getUser({user_name, password}) {
     const user = await users.findOne({
-      $or: [{email: username}, {username: username}]
+      $or: [{email: user_name}, {user_name: user_name}]
     })
     if (!user) {
       throw Error("Invalid user")
@@ -82,9 +82,9 @@ module.exports = async function() {
   //Update base on userId
   //PUT /api/users/:userId
   async function updateUser({userId, updatedUser, userRole}) {
-    if (updatedUser.email || updatedUser.username) {
+    if (updatedUser.email || updatedUser.user_name) {
       const user = await users.findOne({
-        $or: [{email: updatedUser.email}, {username: updatedUser.username}]
+        $or: [{email: updatedUser.email}, {user_name: updatedUser.user_name}]
       })
       if (user) {
         if (user._id != userId) {
@@ -462,13 +462,18 @@ module.exports = async function() {
 
   //Create
   //POST /api/categories
-  async function createCategory({category_name}) {
+  async function createCategory({category_name, resource}) {
     if (!category_name) {
       throw Error("Require a category name")
     }
 
+    if (!resource) {
+      throw Error("Require a resource")
+    }
+
     const result = await categories.insertOne({
-      category_name
+      category_name,
+      resource
     })
     return result
   }
@@ -682,7 +687,8 @@ module.exports = async function() {
       },
       {
         $project: {
-          'revision_history.user.password': 0
+          'revision_history.user.password': 0,
+          'revision_history.user.role': 0
         }
       }
     ]
@@ -868,7 +874,8 @@ module.exports = async function() {
       },
       {
         $project: {
-          'revision_history.user.password': 0
+          'revision_history.user.password': 0,
+          'revision_history.user.role': 0
         }
       }
     ]
@@ -1048,7 +1055,8 @@ module.exports = async function() {
       },
       {
         $project: {
-          'revision_history.user.password': 0
+          'revision_history.user.password': 0,
+          'revision_history.user.role': 0
         }
       }
     ]
@@ -1244,7 +1252,8 @@ module.exports = async function() {
       },
       {
         $project: {
-          'revision_history.user.password': 0
+          'revision_history.user.password': 0,
+          'revision_history.user.role': 0
         }
       }
     ]
@@ -1428,7 +1437,8 @@ module.exports = async function() {
       },
       {
         $project: {
-          'revision_history.user.password': 0
+          'revision_history.user.password': 0,
+          'revision_history.user.role': 0
         }
       }
     ]
@@ -1626,7 +1636,8 @@ module.exports = async function() {
       },
       {
         $project: {
-          'revision_history.user.password': 0
+          'revision_history.user.password': 0,
+          'revision_history.user.role': 0
         }
       }
     ]

--- a/server/mongoDatabase.js
+++ b/server/mongoDatabase.js
@@ -645,9 +645,9 @@ module.exports = async function() {
       {
         $lookup: {
           from: 'revisions',
-          localField: 'revisions',
+          localField: 'revision_history',
           foreignField: '_id',
-          as: 'revisions'
+          as: 'revision_history'
         }
       }
     ]
@@ -729,7 +729,7 @@ module.exports = async function() {
     //New revision for when plant is created
     const revision = await createRevision({user_id: user_id})
 
-    newPlant.revisions = [ObjectID(revision.ops[0]._id)]
+    newPlant.revision_history = [ObjectID(revision.ops[0]._id)]
 
     const result = await plants.insertOne({
       ...newPlant
@@ -797,9 +797,9 @@ module.exports = async function() {
       {
         $lookup: {
           from: 'revisions',
-          localField: 'revisions',
+          localField: 'revision_history',
           foreignField: '_id',
-          as: 'revisions'
+          as: 'revision_history'
         }
       }
     ]
@@ -852,8 +852,8 @@ module.exports = async function() {
     const revision = await createRevision({user_id: user_id})
 
     const plant = await plants.findOne({_id: ObjectID(plantId)})
-    updatedPlant.revisions = plant.revisions
-    updatedPlant.revisions.push(ObjectID(revision.ops[0]._id))
+    updatedPlant.revision_history = plant.revision_history
+    updatedPlant.revision_history.push(ObjectID(revision.ops[0]._id))
 
     const result = await plants.findOneAndUpdate(
       {_id: ObjectID(plantId)},
@@ -866,7 +866,7 @@ module.exports = async function() {
   //DELETE /api/plants/:plantId
   async function deletePlant({plantId}) {
     const plant = await plants.findOne({_id: ObjectID(plantId)})
-    plant.revisions.forEach(async(revision) => {
+    plant.revision_history.forEach(async(revision) => {
       await deleteRevision({revisionId: revision})
     })
 
@@ -935,9 +935,9 @@ module.exports = async function() {
       {
         $lookup: {
           from: 'revisions',
-          localField: 'revisions',
+          localField: 'revision_history',
           foreignField: '_id',
-          as: 'revisions'
+          as: 'revision_history'
         }
       },
       {
@@ -1029,7 +1029,7 @@ module.exports = async function() {
     //New revision for when waypoint is created
     const revision = await createRevision({user_id: user_id})
 
-    newWaypoint.revisions = [ObjectID(revision.ops[0]._id)]
+    newWaypoint.revision_history = [ObjectID(revision.ops[0]._id)]
 
     const result = await waypoints.insertOne({
       ...newWaypoint
@@ -1097,9 +1097,9 @@ module.exports = async function() {
       {
         $lookup: {
           from: 'revisions',
-          localField: 'revisions',
+          localField: 'revision_history',
           foreignField: '_id',
-          as: 'revisions'
+          as: 'revision_history'
         }
       },
       {
@@ -1164,8 +1164,8 @@ module.exports = async function() {
     const revision = await createRevision({user_id: user_id})
 
     const waypoint = await waypoints.findOne({_id: ObjectID(waypointId)})
-    updatedWaypoint.revisions = waypoint.revisions
-    updatedWaypoint.revisions.push(ObjectID(revision.ops[0]._id))
+    updatedWaypoint.revision_history = waypoint.revision_history
+    updatedWaypoint.revision_history.push(ObjectID(revision.ops[0]._id))
 
     const result = await waypoints.findOneAndUpdate(
       {_id: ObjectID(waypointId)},
@@ -1178,7 +1178,7 @@ module.exports = async function() {
   //DELETE /api/waypoints/:waypointId
   async function deleteWaypoint({waypointId}) {
     const waypoint = await waypoints.findOne({_id: ObjectID(waypointId)})
-    waypoint.revisions.forEach(async(revision) => {
+    waypoint.revision_history.forEach(async(revision) => {
       await deleteRevision({revisionId: revision})
     })
 

--- a/server/mongoDatabase.js
+++ b/server/mongoDatabase.js
@@ -668,6 +668,11 @@ module.exports = async function() {
         }
       },
       {
+        $sort: {
+          'revision_history.date': -1
+        }
+      },
+      {
         $lookup: {
           from: 'users',
           localField: 'revision_history.user',
@@ -855,6 +860,11 @@ module.exports = async function() {
         }
       },
       {
+        $sort: {
+          'revision_history.date': -1
+        }
+      },
+      {
         $lookup: {
           from: 'users',
           localField: 'revision_history.user',
@@ -1033,6 +1043,11 @@ module.exports = async function() {
       {
         $unwind: {
           path: '$revision_history'
+        }
+      },
+      {
+        $sort: {
+          'revision_history.date': -1
         }
       },
       {
@@ -1233,6 +1248,11 @@ module.exports = async function() {
         }
       },
       {
+        $sort: {
+          'revision_history.date': -1
+        }
+      },
+      {
         $lookup: {
           from: 'users',
           localField: 'revision_history.user',
@@ -1415,6 +1435,11 @@ module.exports = async function() {
       {
         $unwind: {
           path: '$revision_history'
+        }
+      },
+      {
+        $sort: {
+          'revision_history.date': -1
         }
       },
       {
@@ -1614,6 +1639,11 @@ module.exports = async function() {
       {
         $unwind: {
           path: '$revision_history'
+        }
+      },
+      {
+        $sort: {
+          'revision_history.date': -1
         }
       },
       {

--- a/server/mongoDatabase.js
+++ b/server/mongoDatabase.js
@@ -667,6 +667,9 @@ module.exports = async function() {
       {
         $group: {
           _id: '$_id',
+          plant_name: {$first: '$plant_name'},
+          scientific_name: {$first: '$scientific_name'},
+          description: {$first: '$description'},
           images: {$first: '$images'},
           audio_files: {$first: '$audio_files'},
           videos: {$first: '$videos'},
@@ -850,6 +853,9 @@ module.exports = async function() {
       {
         $group: {
           _id: '$_id',
+          plant_name: {$first: '$plant_name'},
+          scientific_name: {$first: '$scientific_name'},
+          description: {$first: '$description'},
           images: {$first: '$images'},
           audio_files: {$first: '$audio_files'},
           videos: {$first: '$videos'},
@@ -1027,6 +1033,8 @@ module.exports = async function() {
       {
         $group: {
           _id: '$_id',
+          waypoint_name: {$first: '$waypoint_name'},
+          description: {$first: '$description'},
           images: {$first: '$images'},
           audio_files: {$first: '$audio_files'},
           videos: {$first: '$videos'},
@@ -1221,6 +1229,8 @@ module.exports = async function() {
       {
         $group: {
           _id: '$_id',
+          waypoint_name: {$first: '$waypoint_name'},
+          description: {$first: '$description'},
           images: {$first: '$images'},
           audio_files: {$first: '$audio_files'},
           videos: {$first: '$videos'},
@@ -1403,6 +1413,8 @@ module.exports = async function() {
       {
         $group: {
           _id: '$_id',
+          tour_name: {$first: '$tour_name'},
+          description: {$first: '$description'},
           images: {$first: '$images'},
           audio_files: {$first: '$audio_files'},
           videos: {$first: '$videos'},
@@ -1599,6 +1611,8 @@ module.exports = async function() {
       {
         $group: {
           _id: '$_id',
+          tour_name: {$first: '$tour_name'},
+          description: {$first: '$description'},
           images: {$first: '$images'},
           audio_files: {$first: '$audio_files'},
           videos: {$first: '$videos'},

--- a/server/mongoDatabase.js
+++ b/server/mongoDatabase.js
@@ -503,6 +503,12 @@ module.exports = async function() {
     return result
   }
 
+  //Get base on resource
+  //GET /api/categories/group/:group?key=<API_KEY>
+  async function getCategoryGroup({group}) {
+    return await categories.find({resource: group}).toArray()
+  }
+
   //Locations
   
   //Get All
@@ -1756,6 +1762,7 @@ module.exports = async function() {
     getCategory,
     updateCategory,
     deleteCategory,
+    getCategoryGroup,
     //Location
     getLocations,
     createLocation,

--- a/server/mongoDatabase.js
+++ b/server/mongoDatabase.js
@@ -577,7 +577,7 @@ module.exports = async function() {
 
     const result = await revisions.insertOne({
       user_id: ObjectID(user_id),
-      date: Date.now().toString()
+      date: Date.now()
     })
     return result
   }

--- a/server/mongoDatabase.js
+++ b/server/mongoDatabase.js
@@ -1,6 +1,5 @@
 const {MongoClient, ObjectID} = require('mongodb')
 const bcrypt = require('bcryptjs')
-const e = require('express')
 require('dotenv').config()
 
 const url = process.env.MONGO_DB_URL

--- a/server/mongoDatabase.js
+++ b/server/mongoDatabase.js
@@ -1268,78 +1268,86 @@ module.exports = async function() {
 
   //Create
   //POST /api/tours
-  async function createTour({newtour, user_id}) {
+  async function createTour({newTour, user_id}) {
     //Check required none array field first
-    if(!newtour.tour_name) {
+    if(!newTour.tour_name) {
       throw Error("Missing tour name")
     }
 
-    if(!newtour.description) {
+    if(!newTour.description) {
       throw Error("Missing description")
     }
 
     //Convert all passed in array of id to ObjectId
     //Require passing in array of string
     //Default to empty array if the field is not given
-    if(newtour.images) {
-      newtour.images.forEach((image, index, self) => {
+    if(newTour.images) {
+      newTour.images.forEach((image, index, self) => {
         self[index] = ObjectID(image)
       })
     } else {
-      newtour.images = []
+      newTour.images = []
     }
 
-    if(newtour.audio_files) {
-      newtour.audio_files.forEach((audio, index, self) => {
+    if(newTour.audio_files) {
+      newTour.audio_files.forEach((audio, index, self) => {
         self[index] = ObjectID(audio)
       })
     } else {
-      newtour.audio_files = []
+      newTour.audio_files = []
     }
 
-    if(newtour.videos) {
-      newtour.videos.forEach((video, index, self) => {
+    if(newTour.videos) {
+      newTour.videos.forEach((video, index, self) => {
         self[index] = ObjectID(video)
       })
     } else {
-      newtour.videos = []
+      newTour.videos = []
     }
 
-    if(newtour.tags) {
-      newtour.tags.forEach((tag, index, self) => {
+    if(newTour.tags) {
+      newTour.tags.forEach((tag, index, self) => {
         self[index] = ObjectID(tag)
       })
     } else {
-      newtour.tags = []
+      newTour.tags = []
     }
 
-    if(newtour.categories) {
-      newtour.categories.forEach((category, index, self) => {
+    if(newTour.categories) {
+      newTour.categories.forEach((category, index, self) => {
         self[index] = ObjectID(category)
       })
     } else {
-      newtour.categories = []
+      newTour.categories = []
     }
 
-    if(newtour.plants) {
-      newtour.plants.forEach((plant, index, self) => {
+    if(newTour.plants) {
+      newTour.plants.forEach((plant, index, self) => {
         self[index] = ObjectID(plant)
       })
     } else {
-      newtour.plants = []
+      newTour.plants = []
     }
 
-    if(!newtour.custom_fields) {
-      newtour.custom_fields = []
+    if(newTour.waypoints) {
+      newTour.waypoints.forEach((waypoint, index, self) => {
+        self[index] = ObjectID(waypoint)
+      })
+    } else {
+      newTour.waypoints = []
+    }
+
+    if(!newTour.custom_fields) {
+      newTour.custom_fields = []
     }
 
     //New revision for when tour is created
     const revision = await createRevision({user_id: user_id})
 
-    newtour.revision_history = [ObjectID(revision.ops[0]._id)]
+    newTour.revision_history = [ObjectID(revision.ops[0]._id)]
 
     const result = await tours.insertOne({
-      ...newtour
+      ...newTour
     })
     return result
   }
@@ -1424,42 +1432,48 @@ module.exports = async function() {
 
   //Update
   //PUT /api/tours/:tourId
-  async function updateTour({tourId, updatedtour, user_id}) {
+  async function updateTour({tourId, updatedTour, user_id}) {
     //Convert all passed in array of id to ObjectId
     //User should get data of the tour when they start editing
-    if(updatedtour.images) {
-      updatedtour.images.forEach((image, index, self) => {
+    if(updatedTour.images) {
+      updatedTour.images.forEach((image, index, self) => {
         self[index] = ObjectID(image)
       })
     }
 
-    if(updatedtour.audio_files) {
-      updatedtour.audio_files.forEach((audio, index, self) => {
+    if(updatedTour.audio_files) {
+      updatedTour.audio_files.forEach((audio, index, self) => {
         self[index] = ObjectID(audio)
       })
     }
 
-    if(updatedtour.videos) {
-      updatedtour.videos.forEach((video, index, self) => {
+    if(updatedTour.videos) {
+      updatedTour.videos.forEach((video, index, self) => {
         self[index] = ObjectID(video)
       })
     }
 
-    if(updatedtour.tags) {
-      updatedtour.tags.forEach((tag, index, self) => {
+    if(updatedTour.tags) {
+      updatedTour.tags.forEach((tag, index, self) => {
         self[index] = ObjectID(tag)
       })
     }
 
-    if(updatedtour.categories) {
-      updatedtour.categories.forEach((category, index, self) => {
+    if(updatedTour.categories) {
+      updatedTour.categories.forEach((category, index, self) => {
         self[index] = ObjectID(category)
       })
     }
 
-    if(updatedtour.plants) {
-      updatedtour.plants.forEach((plant, index, self) => {
+    if(updatedTour.plants) {
+      updatedTour.plants.forEach((plant, index, self) => {
         self[index] = ObjectID(plant)
+      })
+    }
+
+    if(updatedTour.waypoints) {
+      updatedTour.waypoints.forEach((waypoint, index, self) => {
+        self[index] = ObjectID(waypoint)
       })
     }
 
@@ -1467,12 +1481,12 @@ module.exports = async function() {
     const revision = await createRevision({user_id: user_id})
 
     const tour = await tours.findOne({_id: ObjectID(tourId)})
-    updatedtour.revision_history = tour.revision_history
-    updatedtour.revision_history.push(ObjectID(revision.ops[0]._id))
+    updatedTour.revision_history = tour.revision_history
+    updatedTour.revision_history.push(ObjectID(revision.ops[0]._id))
 
     const result = await tours.findOneAndUpdate(
       {_id: ObjectID(tourId)},
-      {$set: {...updatedtour}}
+      {$set: {...updatedTour}}
     )
     return result
   }

--- a/server/mongoDatabase.js
+++ b/server/mongoDatabase.js
@@ -1011,7 +1011,7 @@ module.exports = async function() {
     if(newWaypoint.location) {
       newWaypoint.location = ObjectID(newWaypoint.location)
     } else {
-      newWaypoint.location = ""
+      throw Error("Missing location")
     }
 
     if(newWaypoint.plants) {

--- a/server/routers/audiosRouter.js
+++ b/server/routers/audiosRouter.js
@@ -21,7 +21,7 @@ module.exports = function({database, authorize, verifyKey, upload, s3}) {
     try {
       const url = req.file ? req.file.location : null
       const result = await database.createAudio({url: url, updatedAudio: req.body})
-      res.send("Audio file added")
+      res.send(result.ops[0])
     } catch (error) {
       console.error(error)
       res.status(401).send({error: error.message})

--- a/server/routers/categoriesRouter.js
+++ b/server/routers/categoriesRouter.js
@@ -66,5 +66,18 @@ module.exports = function({database, authorize, verifyKey}) {
     }
   })
 
+  //Get base on resource
+  //GET /api/categories/group/:group?key=<API_KEY>
+  router.get('/group/:group', verifyKey, async (req, res) => {
+    try {
+      const group = req.params.group
+      const result = await database.getCategoryGroup({group})
+      res.send(result)
+    } catch (error) {
+      console.error(error)
+      res.status(401).send({error: error.message})
+    }
+  })
+
   return router
 }

--- a/server/routers/categoriesRouter.js
+++ b/server/routers/categoriesRouter.js
@@ -20,7 +20,7 @@ module.exports = function({database, authorize, verifyKey}) {
   router.post('/', authorize, verifyKey, async (req, res) => {
     try {
       const result = await database.createCategory(req.body)
-      res.send("Category added")
+      res.send(result.ops[0])
     } catch (error) {
       console.error(error)
       res.status(401).send({error: error.message})

--- a/server/routers/imagesRouter.js
+++ b/server/routers/imagesRouter.js
@@ -21,7 +21,7 @@ module.exports = function({database, authorize, verifyKey, upload, s3}) {
     try {
       const url = req.file ? req.file.location : null
       const result = await database.createImage({url: url, updatedImage: req.body})
-      res.send("Image added")
+      res.send(result.ops[0])
     } catch (error) {
       console.error(error)
       res.status(401).send({error: error.message})

--- a/server/routers/locationsRouter.js
+++ b/server/routers/locationsRouter.js
@@ -20,7 +20,7 @@ module.exports = function({database, authorize, verifyKey}) {
   router.post('/', authorize, verifyKey, async (req, res) => {
     try {
       const result = await database.createLocation(req.body)
-      res.send("Location added")
+      res.send(result.ops[0])
     } catch (error) {
       console.error(error)
       res.status(401).send({error: error.message})

--- a/server/routers/tagsRouter.js
+++ b/server/routers/tagsRouter.js
@@ -20,7 +20,7 @@ module.exports = function({database, authorize, verifyKey}) {
   router.post('/', authorize, verifyKey, async (req, res) => {
     try {
       const result = await database.createTag(req.body)
-      res.send("Tag added")
+      res.send(result.ops[0])
     } catch (error) {
       console.error(error)
       res.status(401).send({error: error.message})

--- a/server/routers/toursRouter.js
+++ b/server/routers/toursRouter.js
@@ -1,0 +1,70 @@
+const express = require('express')
+
+module.exports = function({database, authorize, verifyKey}) {
+  const router = express.Router()
+
+  //Get All
+  //GET /api/tours?key=<API_KEY>
+  router.get('/', verifyKey, async (req, res) => {
+    try {
+      const result = await database.getTours()
+      res.send(result)
+    } catch (error) {
+      console.error(error)
+      res.status(401).send({error: error.message})
+    }
+  })
+
+  //Create
+  //POST /api/tours?key=<API_KEY>
+  router.post('/', authorize, verifyKey, async (req, res) => {
+    try {
+      const result = await database.createTour({newtour: req.body, user_id: req.user._id})
+      res.send("Tour added")
+    } catch (error) {
+      console.error(error)
+      res.status(401).send({error: error.message})
+    }
+  })
+
+  //Get One
+  //GET /api/tours/:tourId?key=<API_KEY>
+  router.get('/:tourId', verifyKey, async (req, res) => {
+    try {
+      const tourId = req.params.tourId
+      const result = await database.getTour({tourId})
+      res.send(result)
+    } catch (error) {
+      console.error(error)
+      res.status(401).send({error: error.message})
+    }
+  })
+
+  //Update
+  //PUT /api/tours/:tourId?key=<API_KEY>
+  router.put('/:tourId', authorize, verifyKey, async (req, res) => {
+    try {
+      const tourId = req.params.tourId
+      const result = await database.updateTour({tourId, updatedtour: req.body, user_id: req.user._id})
+      res.send("Tour updated")
+    } catch (error) {
+      console.error(error)
+      res.status(401).send({error: error.message})
+    }
+  })
+
+  //Delete
+  //DELETE /api/tours/:tourId?key=<API_KEY>
+  router.delete('/:tourId', authorize, verifyKey, async (req, res) => {
+    try {
+      const tourId = req.params.tourId
+      const result = await database.deleteTour({tourId})
+      res.send("Tour deleted")
+    } catch (error) {
+      console.error(error)
+      res.status(401).send({error: error.message})
+    }
+  })
+
+  return router
+}

--- a/server/routers/toursRouter.js
+++ b/server/routers/toursRouter.js
@@ -19,7 +19,7 @@ module.exports = function({database, authorize, verifyKey}) {
   //POST /api/tours?key=<API_KEY>
   router.post('/', authorize, verifyKey, async (req, res) => {
     try {
-      const result = await database.createTour({newtour: req.body, user_id: req.user._id})
+      const result = await database.createTour({newTour: req.body, user_id: req.user._id})
       res.send("Tour added")
     } catch (error) {
       console.error(error)
@@ -45,7 +45,7 @@ module.exports = function({database, authorize, verifyKey}) {
   router.put('/:tourId', authorize, verifyKey, async (req, res) => {
     try {
       const tourId = req.params.tourId
-      const result = await database.updateTour({tourId, updatedtour: req.body, user_id: req.user._id})
+      const result = await database.updateTour({tourId, updatedTour: req.body, user_id: req.user._id})
       res.send("Tour updated")
     } catch (error) {
       console.error(error)

--- a/server/routers/usersRouter.js
+++ b/server/routers/usersRouter.js
@@ -9,7 +9,7 @@ module.exports = function({database, authorize, generateToken}) {
     try {
       const result = await database.createUser(req.body)
       const user = result.ops[0]
-      const filteredResult = (({_id, email, username, role}) => ({_id, email, username, role}))(user)
+      const filteredResult = (({_id, email, user_name, role}) => ({_id, email, user_name, role}))(user)
       const accessToken = generateToken(filteredResult)
       res.send({accessToken, user: filteredResult})
     } catch (error) {
@@ -23,7 +23,7 @@ module.exports = function({database, authorize, generateToken}) {
   router.post('/login', async (req, res) => {
     try {
       const result = await database.getUser(req.body)
-      const filteredResult = (({_id, email, username, role}) => ({_id, email, username, role}))(result)
+      const filteredResult = (({_id, email, user_name, role}) => ({_id, email, user_name, role}))(result)
       const accessToken = generateToken(filteredResult)
       res.send({accessToken, user: filteredResult})
     } catch (error) {

--- a/server/routers/videosRouter.js
+++ b/server/routers/videosRouter.js
@@ -21,7 +21,7 @@ module.exports = function({database, authorize, verifyKey, upload, s3}) {
     try {
       const url = req.file ? req.file.location : null
       const result = await database.createVideo({url: url, updatedVideo: req.body})
-      res.send("Video added")
+      res.send(result.ops[0])
     } catch (error) {
       console.error(error)
       res.status(401).send({error: error.message})

--- a/server/server.js
+++ b/server/server.js
@@ -18,6 +18,7 @@ const makeLocationsRouter = require('./routers/locationsRouter')
 const makeRevisionsRouter = require('./routers/revisionsRouter')
 const makePlantsRouter = require('./routers/plantsRouter')
 const makeWaypointsRouter = require('./routers/waypointsRouter')
+const makeToursRouter = require('./routers/toursRouter')
 
 const app = express()
 app.use(express.json())
@@ -81,6 +82,9 @@ mongoDatabase().then((database) => {
 
   const waypointsRouter = makeWaypointsRouter({database, authorize: jwt.authorize, verifyKey: apikey.verifyKey})
   app.use('/api/waypoints', waypointsRouter)
+
+  const toursRouter = makeToursRouter({database, authorize: jwt.authorize, verifyKey: apikey.verifyKey})
+  app.use('/api/tours', toursRouter)
 })
 
 const port = process.env.PORT || 8080


### PR DESCRIPTION
#105 
#106
I made a pull request of the waypoint route earlier but I finish the documentation on this route.
For this route there are the following:

GET /api/waypoints
Get all waypoints

POST /api/waypoints
Create new waypoint

GET /api/waypoints/:waypointId
Get one waypoint by id

PUT /api/waypoints/:waypointId
Update one waypoint

DELETE /api/waypoints/:waypointId
Delete one waypoint

Closes #113 
Tour route, similar to waypoint and plant route.
Includes the following:

GET /api/tours
Get all tours

POST /api/tours
Create new tour

GET /api/tours/:tourId
Get one tour by id

PUT /api/tours/:tourId
Update one tour

DELETE /api/tours/:tourId
Delete one tour

For more information, you can find the documentation in /planning/server/api

Closes #111 
First requested change. Revision_history in plant, waypoint, tour now returns the whole user object within them.

Closes #112 
Second requested change. Category collection now have a field used to group them and can be access with the following endpoint:
GET /api/categories/group/:group

Closes #114 
Third requested change. POST request to image, audio, video, tag, category, and location route will now return the posted object on successful response.

Closes #115 
Fourth requested change. Revision_history in plant, waypoint, and tour is now sorted with the most recent ones on top.

Still working on #116, but that is about all the changes from this pull request.
There are some small name change that may need to be looked at for other pull request.
